### PR TITLE
chore: disable autofixing jsdoc lint warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -114,6 +114,9 @@
   "typescript.tsdk": "ts/.yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "eslint.nodePath": "ts/.yarn/sdks",
+  "eslint.codeActionsOnSave.rules": [
+    "!jsdoc/*"
+  ],
   "prettier.prettierPath": "ts/.yarn/sdks/prettier/index.js",
   "[cpp]": {
     "editor.defaultFormatter": "ms-vscode.cpptools"


### PR DESCRIPTION
# Description

We don't have jsdoc set up on the vast majority of functions so vscode tends to wreck havoc adding empty multiline comments everywhere in the `ts` directory. I've then disabled this in the vscode settings file to allow us to add documentation progressively.

# Checklist:

- [x] I have reviewed my diff in github, line by line.
- [x] Every change is related to the PR description.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this pull request to the issue(s) that it resolves.
- [x] There are no unexpected formatting changes, superfluous debug logs, or commented-out code.
- [x] There are no circuit changes, OR specifications in `/markdown/specs` have been updated.
- [x] There are no circuit changes, OR a cryptographer has been assigned for review.
- [x] I've updated any terraform that needs updating (e.g. environment variables) for deployment.
- [x] The branch has been rebased against the head of its merge target.
- [x] I'm happy for the PR to be merged at the reviewer's next convenience.
- [x] New functions, classes, etc. have been documented according to the doxygen comment format. Classes and structs must have `@brief` describing the intended functionality.
- [x] If existing code has been modified, such documentation has been added or updated.
